### PR TITLE
build.sbt: Add library dependencies for arm64 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,9 @@ libraryDependencies ++= Seq(
   javaEbean,
   javaWs,
   cache,
+  // for ARM64
+  "net.java.dev.jna" % "jna" % "4.3.0",
+  "net.java.dev.jna" % "jna-platform" % "4.3.0",
   // PlayAuthenticat for social login
   // https://github.com/joscha/play-authenticate
   "com.feth" %% "play-authenticate" % "0.6.9",
@@ -37,7 +40,7 @@ libraryDependencies ++= Seq(
   // javahl
   "org.tmatesoft.svnkit" % "svnkit-javahl16" % "1.8.11",
   "net.sourceforge.jexcelapi" % "jxl" % "2.6.10",
-// shiro
+  // shiro
   "org.apache.shiro" % "shiro-core" % "1.2.1",
   // commons-codec
   "commons-codec" % "commons-codec" % "1.2",


### PR DESCRIPTION
오드로이드(ubuntu mate - aarch64)에 yona를 올리려고 하는데... 실행이 안되길래 확인해보니 jna 네이티브 라이브러리에 aarch64 관련 오브젝트 파일이 없어서 실행이 실패합니다.
jna 라이브러리는 paly core 라이브러리에서 사용하는 것으로 보입니다.
jna 4.3.0 버전에서는 aarch64 지원이 추가되있는 것을 확인하였고 의존성 추가를 해서 테스트해보니 잘 됩니다.
라즈베리파이3에서도 추후에는 라즈비안 새버전이 aarch64로 빌드되지 않으려나 싶네요.