### PR TITLE
라벨 카테고리 버그 수정

### DIFF
--- a/app/controllers/IssueLabelApp.java
+++ b/app/controllers/IssueLabelApp.java
@@ -261,7 +261,14 @@ public class IssueLabelApp extends Controller {
         }
 
         IssueLabel label = IssueLabel.finder.byId(id);
+        IssueLabelCategory category = label.category;
         label.delete();
+
+        long labelCategoryRemainCount = IssueLabel.findByProject(label.project).stream().filter(lb -> lb.category.equals(category)).count();
+        if (labelCategoryRemainCount == 0) {
+            category.delete();
+        }
+
         return ok();
     }
 
@@ -390,6 +397,12 @@ public class IssueLabelApp extends Controller {
         }
 
         IssueLabelCategory category = form.get();
+
+        if (IssueLabelCategory.findByProject(category.project).stream()
+            .filter(lc -> lc.name.equals(category.name) && !lc.id.equals(category.id)).count() > 0) {
+            return badRequest(form.errorsAsJson());
+        }
+
         category.id = id;
         category.project =
             Project.findByOwnerAndProjectName(ownerName, projectName);


### PR DESCRIPTION
1. 라벨 카테고리가 모두 삭제될 경우에 화면에서는 카테고리가 보이지 않지만 DB에는 여전히 남아있던 문제 수정
2. 이미 존재하는 라벨 카테고리 이름으로 변경 가능한 버그를 수정