### PR TITLE
Issue 112 - 이슈 글을 쓸 때 단일 라벨 복구가 안되는 문제

### DIFF
--- a/public/javascripts/common/yobi.ui.Select2.js
+++ b/public/javascripts/common/yobi.ui.Select2.js
@@ -191,14 +191,20 @@
                     var data = [evt.object];
                     var element = $(evt.object.element);
                     var select2Object = $(evt.target).data("select2");
+                    var oldData = select2Object.data()
 
                     // Remove label which category is same with selected label from current data
                     // if selected label belonged exclusive category
                     if(element.data("categoryIsExclusive")){
-                        var filtered = _filterLabelInSameCategory(evt.object, select2Object.data());
+                        var categoryId = $(evt.object.element).data("categoryId");
+                        var filtered = _filterLabelInSameCategory(categoryId, oldData);
                         data = data.concat(filtered);
+
+                        if(oldData.length != filtered.length){
+                            _unselect(select2Object, categoryId);
+                        }
                     } else {
-                        data = data.concat(select2Object.data());
+                        data = data.concat(oldData);
                     }
 
                     _rememberLastScrollTop();
@@ -206,7 +212,7 @@
                     // Set data as filtered
                     // and trigger "change" event
                     select2Object.data(data, true);
-
+                
                     if(select2Object.opts.closeOnSelect !== false){
                         select2Object.close();
                     }
@@ -215,9 +221,7 @@
                     return false;
                 }
 
-                function _filterLabelInSameCategory(label, currentData){
-                    var categoryId = $(label.element).data("categoryId");
-
+                function _filterLabelInSameCategory(categoryId, currentData){
                     return currentData.filter(function(data){
                         return (categoryId !== $(data.element).data("categoryId"));
                     });
@@ -239,6 +243,14 @@
 
                 function _onOpenIssueLabel(){
                     _restoreLastScrollTop();
+                }
+
+                // When select2 v3.x is migrated to v4.x, it will probably need to be updated.
+                function _unselect(select2Object, categoryId){
+                    select2Object.results.find(".select2-selected").filter(function(){
+                        var optionElement = $(this).data("select2-data").element; 
+                        return $(optionElement).data("categoryId") === categoryId; 
+                    }).removeClass("select2-selected");
                 }
             }
         };

--- a/public/javascripts/service/yobi.issue.LabelEditor.js
+++ b/public/javascripts/service/yobi.issue.LabelEditor.js
@@ -200,12 +200,12 @@
             if(elements.inputCategory.val().length === 0 ||
                 elements.inputName.val().length === 0 ||
                 elements.inputColor.val().length === 0){
-                $yobi.alert(Messages("label.failed") + "\n" + Messages("label.error.empty"));
+                $yobi.alert(Messages("label.failedTo", Messages("label.add")) + "\n" + Messages("label.error.empty"));
                 return false;
             }
 
             if(_getRefinedHexColor(elements.inputColor.val()) === false){
-                $yobi.alert(Messages("label.failed") + "\n" + Messages("label.error.color", elements.inputColor.val()));
+                $yobi.alert(Messages("label.failedTo", Messages("label.add")) + "\n" + Messages("label.error.color", elements.inputColor.val()));
                 return false;
             }
 


### PR DESCRIPTION
- Issue: #112 
- Yona에서 사용 하는 데이터셋은 Select2가 지원하는 API로 이쁘게 처리 할수 있는 방법이 없어서.. (있을수도 있는데 제가 못 찾았었을수도 있습니다..) 싱글 라벨선택 될때, 기존에 선택되어서 숨겨진 녀석을 찾아서 다시 보이게 수정했습니다. 그리고 `label.failed` 라는 메세지키가 없어서 `label.failedTo`를 사용하긴 했는데.. 영어메세지에서 `Failed to Add label` - `A`가 대문자로 나오는 문제가 있습니다. 어떻게 하는게 내부적인 룰인지 몰라서 일단 있는걸로 수정해보았습니다. 수정/의견 사항 있으면 알려주셔요.

- @doortts 새해복 많이 받으세요!
