### PR TITLE
Admin 페이지의 사용자/프로젝트의 Layout 수정

### DIFF
--- a/app/views/site/projectList.scala.html
+++ b/app/views/site/projectList.scala.html
@@ -23,10 +23,13 @@
         <div class="span5 listhead-title">
             <strong>@Messages("project.name")</strong>
         </div>
-        <div class="span5 listhead-title">
+        <div class="span4 listhead-title">
             <strong>@Messages("project.description")</strong>
         </div>
         <div class="span2 listhead-title">
+            <strong>@Messages("project.created")</strong>
+        </div>
+        <div class="span1 listhead-title">
             <strong>&nbsp;</strong>
         </div>
     </div>

--- a/app/views/site/projectList.scala.html
+++ b/app/views/site/projectList.scala.html
@@ -10,6 +10,7 @@
 @import utils.JodaDateUtil._
 
 @siteMngLayout(message) {
+    <div class="title_area">
         <h2 class="pull-left">@Messages("site.sidebar.projectList")</h2>
         <form class="form-search pull-right" action="@routes.SiteApp.projectList()">
             <div class="search-bar">

--- a/app/views/site/userList.scala.html
+++ b/app/views/site/userList.scala.html
@@ -48,18 +48,18 @@
         <div class="span3 listhead-title">
             <strong>@Messages("user.name")</strong>
         </div>
-        <div class="span4 listhead-title">
+        <div class="span3 listhead-title">
             <strong>@Messages("user.email")</strong>
         </div>
         <div class="span2 listhead-title">
             <strong>@Messages("userinfo.since")</strong>
         </div>
         @if(userState != UserState.DELETED) {
-        <div class="span3 listhead-title">
+        <div class="span4 listhead-title">
             <strong>&nbsp;</strong>
         </div>
         } else {
-        <div class="span3 listhead-title">
+        <div class="span4 listhead-title">
             <strong>@Messages("userinfo.leave")</strong>
         </div>
         }
@@ -101,7 +101,7 @@
                 </button>
             </div>
             } else {
-            <div class="span3 listitem-col">
+            <div class="span4 listitem-col">
                 @user.lastStateModifiedDate
             </div>
             }


### PR DESCRIPTION
  * 프로젝트 리스트가 Layout 에서 벗어나는 현상을 수정하였습니다.
  * 사용자/프로젝트의 List Page (Table) 의 컬럼 사이즈가 어긋나 있어서 이를 수정하였습니다.