### PR TITLE
Fix site index title to Yona.

### DIFF
--- a/app/views/index/notifications.scala.html
+++ b/app/views/index/notifications.scala.html
@@ -10,7 +10,7 @@
 @import utils.JodaDateUtil
 @import utils.MenuType._
 
-@siteLayout(Messages("notification"), utils.MenuType.SITE_HOME) {
+@siteLayout(utils.Config.getSiteName, utils.MenuType.SITE_HOME) {
     @if(currentUser == User.anonymous){
     @partial_intro()
     } else {


### PR DESCRIPTION
https://github.com/yona-projects/yona/commit/222cb49ac02a6ba2e84c7d6d3e6cf74beec0193f 커밋에 의해서 'notification' 으로 변경된 index 페이지 타이틀을 'Yona' 로 복구합니다.