### PR TITLE
SVN 프로젝트에서 코드 네비게이션이 불가능한 문제 수정

### DIFF
--- a/public/javascripts/service/yobi.code.Browser.js
+++ b/public/javascripts/service/yobi.code.Browser.js
@@ -520,11 +520,14 @@
 
             htElement.welBreadCrumbs.html(breadcrumb);
 
-            var path = window.location.hash.substr(1);
             var $newFileLink = $("#new-file-link");
-            var newPath = updateQueryStringParameter($newFileLink.attr("href"), "path", path + "/");
+            var path = window.location.hash.substr(1);
 
-            $newFileLink.attr("href", newPath);
+            // 'New File' Button supports only git repositories.
+            if ($newFileLink[0]) {
+                var newPath = updateQueryStringParameter($newFileLink.attr("href"), "path", path + "/");
+                $newFileLink.attr("href", newPath);
+            }
         }
 
         function updateQueryStringParameter(uri, key, value) {


### PR DESCRIPTION
Yona v.1.4.0 부터 문제를 적용받던 SVN 프로젝트에서 코드 탭을 이용하여 네비게이션이 불가능한 문제를 수정합니다.

관련이슈 : #235 