### PR TITLE
change releases old link to new one

### DIFF
--- a/app/models/YobiUpdate.java
+++ b/app/models/YobiUpdate.java
@@ -43,7 +43,7 @@ public class YobiUpdate {
             .getString("application.update.repositoryUrl", "http://repo.yona.io/yona/yona");
     private static final String RELEASE_URL_FORMAT = Configuration.root()
             .getString("application.update.releaseUrlFormat",
-                    "https://github.com/doortts/yona/releases/tag/v%s");
+                    "https://github.com/yona-projects/yona/releases/tag/v%s");
 
     public static String versionToUpdate = null;
 


### PR DESCRIPTION
안녕하세요. 1.7.0에서도 안 되는 듯 하여, 링크만 수정했습니다.
<img width="429" alt="2017-09-27 2 41 31" src="https://user-images.githubusercontent.com/718691/30897676-7de4377e-a392-11e7-9317-4e85e5fa8c21.png">
