### PR TITLE
deploy yona on cloud with restricted filesystem access

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: target/universal/stage/bin/yona -Dhttp.port=${PORT}

--- a/conf/application.conf.default
+++ b/conf/application.conf.default
@@ -379,4 +379,12 @@ ldap {
     }
 }
 
+# Cloud Environment Configuration
+
+db.default.url=${?MARIA_JDBC_URL}
+db.default.user=${?MARIA_USER}
+db.default.password=${?MARIA_PASSWORD}
+
+application.secret=${?APPLICATION_SECRET}
+
 include "social-login.conf"


### PR DESCRIPTION
### mariadb를 사용해 원격에 디플로이하기 위해 필요한 최소한의 환경변수를 application.conf 에서 옵셔널하게 덮어쓸 수 있도록 바꿉니다.

application.conf.default
```
db.default.url=${?MARIA_JDBC_URL}
db.default.user=${?MARIA_USER}
db.default.password=${?MARIA_PASSWORD}

application.secret=${?APPLICATION_SECRET}
```
### example - deploy on heroku
1. 앞의 세 환경 변수는 미리 세팅 후 yona 디플로이
2. admin 설정 후 재시작 안내 화면이 뜨면 APPLICATION_SECRET 을 임의의 키로 세팅한 후 재시작