### PR TITLE
webhook: Remove whitespace from url on adding (#359)

### DIFF
--- a/app/controllers/ProjectApp.java
+++ b/app/controllers/ProjectApp.java
@@ -1266,7 +1266,7 @@ public class ProjectApp extends Controller {
 
         Webhook webhook = addWebhookForm.get();
 
-        Webhook.create(project.id, webhook.payloadUrl, webhook.secret,
+        Webhook.create(project.id, webhook.payloadUrl.trim(), webhook.secret,
                 BooleanUtils.toBooleanDefaultIfNull(webhook.gitPushOnly, false));
 
         return redirect(routes.ProjectApp.webhooks(project.owner, project.name));


### PR DESCRIPTION
webhook 입력시 공백이 같이 입력되어 오작동이 일어나는 현상을 발견하였습니다.

이를 해결하기 위해 입력시 trim() 을 호출하여 공백을 제거하도록 하였습니다.