### PR TITLE
#query duplication issue

### DIFF
--- a/app/views/index/myOrganizationList.scala.html
+++ b/app/views/index/myOrganizationList.scala.html
@@ -30,7 +30,7 @@
 
     <div class="search-result">
         <div class="group">
-            <input class="search-input org-search" type="text" id="query" autocomplete="off" placeholder="@Messages("title.type.name")">
+            <input class="search-input org-search" type="text" autocomplete="off" placeholder="@Messages("title.type.name")">
             <span class="bar"></span>
         </div>
         @displayOrganizations("organizations", Organization.findOrganizationsByUserLoginId(UserApp.currentUser.loginId), currentUser.getFavoriteOrganizations)


### PR DESCRIPTION
비로그인 상태에서 첫페이지 id="query" 중복으로 인한 Console log 생김.
#query 대신 .org-search 사용 확인하고 삭제함.
<img width="800" alt="2018-03-11 7 22 21" src="https://user-images.githubusercontent.com/718691/37252418-13dfe946-2564-11e8-9d2f-3850a349f7f1.png">
