### PR TITLE
webhook: Fix webhook bug #395 #396

### DIFF
--- a/app/models/Webhook.java
+++ b/app/models/Webhook.java
@@ -318,7 +318,8 @@ public class Webhook extends Model implements ResourceConvertible {
                 play.Logger.warn("Unknown webhook event: " + eventType);
         }
 
-        requestMessage += " <" + utils.Config.getScheme() + "://" + utils.Config.getHostport("localhost:9000") + RouteUtil.getUrl(eventIssue) + "|#" + eventIssue.number + ": " + eventIssue.title + ">";
+        String eventIssueUrl = controllers.routes.IssueApp.issue(eventIssue.project.owner, eventIssue.project.name, eventIssue.getNumber()).url();
+        requestMessage += " <" + utils.Config.getScheme() + "://" + utils.Config.getHostport("localhost:9000") + eventIssueUrl + "|#" + eventIssue.number + ": " + eventIssue.title + ">";
 
         if (this.webhookType == WebhookType.SIMPLE) {
             return buildTextPropertyOnlyJSON(requestMessage);


### PR DESCRIPTION
webhook 설정시 issue 관련 변경사항이 반영되지 않는 버그를 수정하였습니다.
(관련 이슈는 각각 본문과 마일스톤이 변경되지 않는 현상)

RouteUtil 에서 issue 를 refresh 하는 로직을 피하기 위하여 URL 을 바로 추출하는 방식으로 변경하였습니다.