### PR TITLE
fix issue: not working tab in Pull Request #414

### DIFF
--- a/app/views/git/partial_search.scala.html
+++ b/app/views/git/partial_search.scala.html
@@ -127,6 +127,7 @@
             $('.pullrequeset-tab-menu').on('click','[data-type="state"]',function() {
               $('#search').attr('action', $(this).data('url'));
               $('#search').submit();
+              return false;
             });
 
             yobi.ui.Select2("#contributors").on("change", function(){


### PR DESCRIPTION
크롬에서 Pull Request 의 탭이동이 되지 않는 현상을 해결합니다.

문제는 onclick 으로 반응하는 a 태그의 href 속성에 # 이 들어가있기 때문에 주소의 가장 마지막에 # 이 붙으면서 발생하게 됩니다.

이 때문에 onclick event 를 추가할 때 가장 마지막에 `return false;` 를 추가함으로써 href 속성을 무시하도록 하여 문제를 발생시키지 않는 방식으로 해결하였습니다.