### PR TITLE
webhook: Fix webhook bug #426

### DIFF
--- a/app/models/NotificationEvent.java
+++ b/app/models/NotificationEvent.java
@@ -622,6 +622,16 @@ public class NotificationEvent extends Model implements INotificationEvent {
         }
     }
 
+    private static void webhookRequest(EventType eventTypes, Issue issue, Project previous, Boolean gitPushOnly) {
+        List<Webhook> webhookList = Webhook.findByProject(issue.project.id);
+        for (Webhook webhook : webhookList) {
+            if (gitPushOnly == webhook.gitPushOnly) {
+                // Send push event via webhook payload URLs.
+                webhook.sendRequestToPayloadUrl(eventTypes, UserApp.currentUser(), issue, previous);
+            }
+        }
+    }
+
     private static void webhookRequest(EventType eventTypes, Comment comment, Boolean gitPushOnly) {
         List<Webhook> webhookList = Webhook.findByProject(comment.projectId);
         for (Webhook webhook : webhookList) {
@@ -906,7 +916,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
     }
 
     public static NotificationEvent afterIssueMoved(Project previous, Issue issue) {
-        webhookRequest(ISSUE_MOVED, issue, false);
+        webhookRequest(ISSUE_MOVED, issue, previous, false);
 
         NotificationEvent notiEvent = createFromCurrentUser(issue);
         notiEvent.title = formatReplyTitle(issue);


### PR DESCRIPTION
웹훅에서 이슈 프로젝트 이동시 webhook 메세지에 프로젝트 이름이 뜨지 않는 버그를 수정하였습니다.