### PR TITLE
avatar: Fix bug that png file is saved as jpg when uploading #304

### DIFF
--- a/public/javascripts/service/yobi.user.Setting.js
+++ b/public/javascripts/service/yobi.user.Setting.js
@@ -257,7 +257,7 @@
                 // canvas-to-blob.js
                 htElement.elAvatarCropCanvas.toBlob(function(oFile){
                     yobi.Files.uploadFile(oFile, "jCropUpload");
-                }, "image/jpeg", 100);
+                }, elImage.mimeType, 100);
             };
 
             elImage.src = htElement.welAvatarCropImg.attr("src");


### PR DESCRIPTION
avatar upload 시 무조건 jpg 파일로 저장하는 것을 원본 파일 형식에 따라 저장하도록 변경했습니다.