### PR TITLE
mail: Fix mail message bug #427

### DIFF
--- a/app/models/NotificationEvent.java
+++ b/app/models/NotificationEvent.java
@@ -135,7 +135,11 @@ public class NotificationEvent extends Model implements INotificationEvent {
                     return Messages.get(lang, "notification.issue.assigned", newValue);
                 }
             case ISSUE_MILESTONE_CHANGED:
-                return Messages.get(lang, "notification.milestone.changed", newValue);
+                if (Milestone.findById(Long.parseLong(newValue)) == null) {
+                    return Messages.get(lang, "notification.milestone.changed", Messages.get(Lang.defaultLang(), "issue.noMilestone"));
+                } else {
+                    return Messages.get(lang, "notification.milestone.changed", Milestone.findById(Long.parseLong(newValue)).title);
+                }
             case NEW_ISSUE:
             case NEW_POSTING:
             case NEW_COMMENT:


### PR DESCRIPTION
마일스톤 변경이 알림 메일에서 마일스톤 아이디가 숫자로 표기되는 버그를 수정하였습니다.
