### PR TITLE
#564 webhook 에서 이슈 삭제 발송시 메세지가 나타나지 않는 현상 해결

### DIFF
--- a/app/models/Webhook.java
+++ b/app/models/Webhook.java
@@ -362,6 +362,9 @@ public class Webhook extends Model implements ResourceConvertible {
             case ISSUE_MILESTONE_CHANGED:
                 requestMessage += Messages.get(Lang.defaultLang(), "notification.type.milestone.changed");
                 break;
+            case RESOURCE_DELETED:
+                requestMessage += Messages.get(Lang.defaultLang(), "notification.type.issue.deleted");
+                break;
             default:
                 play.Logger.warn("Unknown webhook event: " + eventType);
         }

--- a/conf/messages
+++ b/conf/messages
@@ -473,6 +473,7 @@ notification.send.mail.warning = If you are not the original author, this option
 notification.type.comment.updated = Comment updated
 notification.type.issue.assignee.changed = Issue assignee changed.
 notification.type.issue.body.changed = Issue body changed
+notification.type.issue.deleted = Issue deleted
 notification.type.issue.is.moved = Issue moved
 notification.type.issue.label.changed = Issue label changed
 notification.type.issue.moved = Issue has been moved. From {0} To {1}

--- a/conf/messages.ko-KR
+++ b/conf/messages.ko-KR
@@ -473,6 +473,7 @@ notification.send.mail.warning = 만약 해당글의 원 작성자가 아니라�
 notification.type.comment.updated = 댓글 수정
 notification.type.issue.assignee.changed = 이슈 담당자 변경
 notification.type.issue.body.changed = 이슈 본문 변경
+notification.type.issue.deleted = 이슈 삭제
 notification.type.issue.is.moved = 이슈 이동
 notification.type.issue.label.changed = 이슈 라벨 변경
 notification.type.issue.moved = 이슈가 {0}에서 {1}로 이동되었습니다


### PR DESCRIPTION
이슈 삭제시 알람 이벤트 코드 및 메세지 추가