### PR TITLE
#583 Project 이동시 중복 요청 발생 방지

### DIFF
--- a/conf/evolutions/default/28.sql
+++ b/conf/evolutions/default/28.sql
@@ -1,5 +1,0 @@
-# --- !Ups
-ALTER TABLE project_transfer ADD uq_project_transfer_1 UNIQUE (sender_id, destination, project_id);
-
-# --- !Downs
-ALTER TABLE project_transfer DROP INDEX uq_project_transfer_1

--- a/conf/evolutions/default/28.sql
+++ b/conf/evolutions/default/28.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+ALTER TABLE project_transfer ADD uq_project_transfer_1 UNIQUE (sender_id, destination, project_id);
+
+# --- !Downs
+ALTER TABLE project_transfer DROP INDEX uq_project_transfer_1

--- a/public/javascripts/service/yobi.project.Transfer.js
+++ b/public/javascripts/service/yobi.project.Transfer.js
@@ -48,7 +48,7 @@
         function _attachEvent(htOptions){
             htElement.welBtnTransferPop.click(_onClickBtnTransferPop);
 
-            htElement.welBtnTransferPrj.on("click", function(){
+            htElement.welBtnTransferPrj.one("click", function(){
                 $.ajax(htOptions.sTransferURL + "?owner=" + $("#owner").val(), {
                     "method" : "put",
                     "success": function(oRes, sStatus, oXHR){


### PR DESCRIPTION
Project 이동시 중복 요청 발생 방지를 위한 Front-end 의 코드 수정
(Project 이동 기능 발생 버튼을 on() 대신 one() 을 사용하여 한번만 발생하도록 수정)

추가적으로 DB 에도 unique 조건을 추가하였습니다.
(실제로 해당 문제가 발생한 경우 Project 이동시 에러가 발생하여 DB 단에서 하나를 지워줘야 함)

@doortts 
DB 와 관련된 부분은 sender 까지 걸지 않아도 될 것 같긴 한데,
확인을 요청 드립니다.

+ #584 의 sql 때문에 해당 PR Merge 후 Merge 되어야 할 것 같습니다.