### PR TITLE
#632 #624 git push 시 webhook 발생

### DIFF
--- a/app/controllers/ProjectApp.java
+++ b/app/controllers/ProjectApp.java
@@ -1305,7 +1305,7 @@ public class ProjectApp extends Controller {
     private static void createWebhook(Project project, Form<Webhook> forms) {
         Webhook webhook = forms.get();
         webhook.project = project;
-        if(webhook.gitPushOnly == null) webhook.gitPushOnly = false;
+        if(webhook.gitPush == null) webhook.gitPush = false;
         webhook.createdAt = new Date();
         webhook.save();
     }

--- a/app/models/NotificationEvent.java
+++ b/app/models/NotificationEvent.java
@@ -673,6 +673,8 @@ public class NotificationEvent extends Model implements INotificationEvent {
         for (Webhook webhook : webhookList) {
             if (gitPushOnly == webhook.gitPushOnly) {
                 // Send push event via webhook payload URLs.
+                webhook.sendRequestToPayloadUrl(commits, refNames, sender);
+            } else {
                 webhook.sendRequestToPayloadUrl(commits, refNames, sender, title);
             }
         }

--- a/app/models/NotificationEvent.java
+++ b/app/models/NotificationEvent.java
@@ -598,83 +598,83 @@ public class NotificationEvent extends Model implements INotificationEvent {
         return resourceId;
     }
 
-    private static void webhookRequest(EventType eventTypes, PullRequest pullRequest, Boolean gitPushOnly) {
+    private static void webhookRequest(EventType eventTypes, PullRequest pullRequest) {
         List<Webhook> webhookList = eventTypes == PULL_REQUEST_MERGED ? Webhook.findByProject(pullRequest.toProject.id) : Webhook.findByProject(pullRequest.toProjectId);
         for (Webhook webhook : webhookList) {
-            if (gitPushOnly == webhook.gitPushOnly) {
+            if (webhook.webhookType != WebhookType.JSON) {
                 // Send push event via webhook payload URLs.
                 webhook.sendRequestToPayloadUrl(eventTypes, UserApp.currentUser(), pullRequest);
             }
         }
     }
 
-    private static void webhookRequest(EventType eventTypes, PullRequest pullRequest, PullRequestReviewAction reviewAction, Boolean gitPushOnly) {
+    private static void webhookRequest(EventType eventTypes, PullRequest pullRequest, PullRequestReviewAction reviewAction) {
         List<Webhook> webhookList = Webhook.findByProject(pullRequest.toProject.id);
         for (Webhook webhook : webhookList) {
-            if (gitPushOnly == webhook.gitPushOnly) {
+            if (webhook.webhookType != WebhookType.JSON) {
                 // Send push event via webhook payload URLs.
                 webhook.sendRequestToPayloadUrl(eventTypes, UserApp.currentUser(), pullRequest, reviewAction);
             }
         }
     }
 
-    private static void webhookRequest(EventType eventTypes, Issue issue, Boolean gitPushOnly) {
+    private static void webhookRequest(EventType eventTypes, Issue issue) {
         List<Webhook> webhookList = Webhook.findByProject(issue.project.id);
         for (Webhook webhook : webhookList) {
-            if (gitPushOnly == webhook.gitPushOnly) {
+            if (webhook.webhookType != WebhookType.JSON) {
                 // Send push event via webhook payload URLs.
                 webhook.sendRequestToPayloadUrl(eventTypes, UserApp.currentUser(), issue);
             }
         }
     }
 
-    private static void webhookRequest(EventType eventTypes, Issue issue, Project previous, Boolean gitPushOnly) {
+    private static void webhookRequest(EventType eventTypes, Issue issue, Project previous) {
         List<Webhook> webhookList = Webhook.findByProject(issue.project.id);
         for (Webhook webhook : webhookList) {
-            if (gitPushOnly == webhook.gitPushOnly) {
+            if (webhook.webhookType != WebhookType.JSON) {
                 // Send push event via webhook payload URLs.
                 webhook.sendRequestToPayloadUrl(eventTypes, UserApp.currentUser(), issue, previous);
             }
         }
     }
 
-    private static void webhookRequest(EventType eventTypes, Posting post, Boolean gitPushOnly) {
+    private static void webhookRequest(EventType eventTypes, Posting post) {
         List<Webhook> webhookList = Webhook.findByProject(post.project.id);
         for (Webhook webhook : webhookList) {
-            if (gitPushOnly == webhook.gitPushOnly) {
+            if (webhook.webhookType != WebhookType.JSON) {
                 // Send push event via webhook payload URLs.
                 webhook.sendRequestToPayloadUrl(eventTypes, UserApp.currentUser(), post);
             }
         }
     }
 
-    private static void webhookRequest(EventType eventTypes, Comment comment, Boolean gitPushOnly) {
+    private static void webhookRequest(EventType eventTypes, Comment comment) {
         List<Webhook> webhookList = Webhook.findByProject(comment.projectId);
         for (Webhook webhook : webhookList) {
-            if (gitPushOnly == webhook.gitPushOnly) {
+            if (webhook.webhookType != WebhookType.JSON) {
                 // Send push event via webhook payload URLs.
                 webhook.sendRequestToPayloadUrl(eventTypes, UserApp.currentUser(), comment);
             }
         }
     }
 
-    private static void webhookRequest(EventType eventTypes, PullRequest pullRequest, ReviewComment reviewComment, Boolean gitPushOnly) {
+    private static void webhookRequest(EventType eventTypes, PullRequest pullRequest, ReviewComment reviewComment) {
         List<Webhook> webhookList = Webhook.findByProject(pullRequest.toProject.id);
         for (Webhook webhook : webhookList) {
-            if (gitPushOnly == webhook.gitPushOnly) {
+            if (webhook.webhookType != WebhookType.JSON) {
                 // Send push event via webhook payload URLs.
                 webhook.sendRequestToPayloadUrl(eventTypes, UserApp.currentUser(), pullRequest, reviewComment);
             }
         }
     }
 
-    private static void webhookRequest(Project project, List<RevCommit> commits, List<String> refNames, User sender, String title, Boolean gitPushOnly) {
+    private static void webhookRequest(Project project, List<RevCommit> commits, List<String> refNames, User sender, String title) {
         List<Webhook> webhookList = Webhook.findByProject(project.id);
         for (Webhook webhook : webhookList) {
-            if (gitPushOnly == webhook.gitPushOnly) {
+            if (webhook.webhookType == WebhookType.JSON) {
                 // Send push event via webhook payload URLs.
                 webhook.sendRequestToPayloadUrl(commits, refNames, sender);
-            } else {
+            } else if (webhook.gitPush == true){
                 webhook.sendRequestToPayloadUrl(commits, refNames, sender, title);
             }
         }
@@ -694,7 +694,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
         NotificationEvent.add(notiEvent);
 
         if (newState == State.MERGED) {
-            webhookRequest(PULL_REQUEST_MERGED, pullRequest, false);
+            webhookRequest(PULL_REQUEST_MERGED, pullRequest);
         }
 
         return notiEvent;
@@ -709,7 +709,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
         notiEvent.newValue = newPullRequestCommitChangedMessage(pullRequest);
         NotificationEvent.add(notiEvent);
 
-        webhookRequest(PULL_REQUEST_COMMIT_CHANGED, pullRequest, false);
+        webhookRequest(PULL_REQUEST_COMMIT_CHANGED, pullRequest);
 
         return notiEvent;
     }
@@ -753,7 +753,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
     }
 
     public static NotificationEvent forNewComment(User sender, PullRequest pullRequest, ReviewComment newComment) {
-        webhookRequest(NEW_REVIEW_COMMENT, pullRequest, newComment, false);
+        webhookRequest(NEW_REVIEW_COMMENT, pullRequest, newComment);
 
         NotificationEvent notiEvent = createFrom(sender, newComment);
         notiEvent.title = formatReplyTitle(pullRequest);
@@ -768,7 +768,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
     }
 
     public static NotificationEvent afterNewPullRequest(PullRequest pullRequest) {
-        webhookRequest(NEW_PULL_REQUEST, pullRequest, false);
+        webhookRequest(NEW_PULL_REQUEST, pullRequest);
         return afterNewPullRequest(UserApp.currentUser(), pullRequest);
     }
 
@@ -777,7 +777,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
     }
 
     public static void afterNewComment(Comment comment) {
-        webhookRequest(NEW_COMMENT, comment, false);
+        webhookRequest(NEW_COMMENT, comment);
         NotificationEvent.add(forNewComment(comment, UserApp.currentUser()));
     }
 
@@ -822,7 +822,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
     }
 
     public static NotificationEvent afterStateChanged(State oldState, Issue issue) {
-        webhookRequest(ISSUE_STATE_CHANGED, issue, false);
+        webhookRequest(ISSUE_STATE_CHANGED, issue);
 
         NotificationEvent notiEvent = createFromCurrentUser(issue);
         notiEvent.title = formatReplyTitle(issue);
@@ -870,7 +870,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
     }
 
     public static NotificationEvent afterAssigneeChanged(User oldAssignee, Issue issue) {
-        webhookRequest(ISSUE_ASSIGNEE_CHANGED, issue, false);
+        webhookRequest(ISSUE_ASSIGNEE_CHANGED, issue);
 
         NotificationEvent notiEvent = createFromCurrentUser(issue);
 
@@ -905,7 +905,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
     public static NotificationEvent afterNewIssue(Issue issue) {
         NotificationEvent notiEvent = forNewIssue(issue, UserApp.currentUser());
         NotificationEvent.add(notiEvent);
-        webhookRequest(NEW_ISSUE, issue, false);
+        webhookRequest(NEW_ISSUE, issue);
         return notiEvent;
     }
 
@@ -929,13 +929,13 @@ public class NotificationEvent extends Model implements INotificationEvent {
 
         NotificationEvent.add(notiEvent);
         if (item instanceof Issue) {
-            webhookRequest(RESOURCE_DELETED, (Issue)item, false);
+            webhookRequest(RESOURCE_DELETED, (Issue)item);
         }
         return notiEvent;
     }
 
     public static NotificationEvent afterIssueBodyChanged(String oldBody, Issue issue) {
-        webhookRequest(ISSUE_BODY_CHANGED, issue, false);
+        webhookRequest(ISSUE_BODY_CHANGED, issue);
 
         NotificationEvent notiEvent = createFromCurrentUser(issue);
         notiEvent.title = formatReplyTitle(issue);
@@ -950,7 +950,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
     }
 
     public static NotificationEvent afterIssueMoved(Project previous, Issue issue, Supplier<Set<User>> getReceivers) {
-        webhookRequest(ISSUE_MOVED, issue, previous, false);
+        webhookRequest(ISSUE_MOVED, issue, previous);
 
         NotificationEvent notiEvent = createFromCurrentUser(issue);
         notiEvent.title = formatReplyTitle(issue);
@@ -1004,7 +1004,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
         if (issue.milestone != null) {
             issue.milestone.refresh();
         }
-        webhookRequest(ISSUE_MILESTONE_CHANGED, issue, false);
+        webhookRequest(ISSUE_MILESTONE_CHANGED, issue);
 
         NotificationEvent notiEvent = createFromCurrentUser(issue);
 
@@ -1137,7 +1137,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
 
     public static void afterNewPost(Posting post) {
         NotificationEvent.add(forNewPosting(post, UserApp.currentUser()));
-        webhookRequest(NEW_POSTING, post, false);
+        webhookRequest(NEW_POSTING, post);
     }
 
     public static void afterUpdatePosting(String oldValue, Posting post) {
@@ -1283,11 +1283,11 @@ public class NotificationEvent extends Model implements INotificationEvent {
         notiEvent.resourceId = project.asResource().getId();
         NotificationEvent.add(notiEvent);
 
-        webhookRequest(project, commits, refNames, sender, title, true);
+        webhookRequest(project, commits, refNames, sender, title);
     }
 
     public static NotificationEvent afterReviewed(PullRequest pullRequest, PullRequestReviewAction reviewAction) {
-        webhookRequest(EventType.PULL_REQUEST_REVIEW_STATE_CHANGED, pullRequest, reviewAction, false);
+        webhookRequest(EventType.PULL_REQUEST_REVIEW_STATE_CHANGED, pullRequest, reviewAction);
 
         String title = formatReplyTitle(pullRequest);
         Resource resource = pullRequest.asResource();
@@ -1624,7 +1624,7 @@ public class NotificationEvent extends Model implements INotificationEvent {
     }
 
     public static void afterCommentUpdated(Comment comment) {
-        webhookRequest(COMMENT_UPDATED, comment, false);
+        webhookRequest(COMMENT_UPDATED, comment);
         NotificationEvent.add(forUpdatedComment(comment, UserApp.currentUser()));
     }
 

--- a/app/models/Webhook.java
+++ b/app/models/Webhook.java
@@ -82,9 +82,9 @@ public class Webhook extends Model implements ResourceConvertible {
     public String secret;
 
     /**
-     * Condition of sending webhook (true: git only push, false: all cases)
+     * Condition of sending webhook (true = include git push event, false = exclude git push event)
      */
-    public Boolean gitPushOnly;
+    public Boolean gitPush;
 
     public WebhookType webhookType = WebhookType.SIMPLE;
 
@@ -96,17 +96,18 @@ public class Webhook extends Model implements ResourceConvertible {
      *
      * @param projectId the ID of project which will have this webhook
      * @param payloadUrl the payload URL for this webhook
-     * @param gitPushOnly type of webhook (true = git only push, false = all cases)
+     * @param gitPush type of webhook (true = include git push event, false = exclude git push event)
      * @param secret the secret token for server identity
      */
-    public Webhook(Long projectId, String payloadUrl, String secret, Boolean gitPushOnly) {
+    public Webhook(Long projectId, String payloadUrl, String secret, Boolean gitPush, WebhookType webhookType) {
         if (secret == null) {
             secret = "";
         }
         this.project = Project.find.byId(projectId);
         this.payloadUrl = payloadUrl;
         this.secret = secret;
-        this.gitPushOnly = gitPushOnly;
+        this.gitPush = gitPush;
+        this.webhookType = webhookType;
         this.createdAt = new Date();
     }
 
@@ -137,9 +138,9 @@ public class Webhook extends Model implements ResourceConvertible {
         return find.where().eq("project.id", projectId).findList();
     }
 
-    public static void create(Long projectId, String payloadUrl, String secret, Boolean gitPushOnly) {
+    public static void create(Long projectId, String payloadUrl, String secret, Boolean gitPush, WebhookType webhookType) {
         if (!payloadUrl.isEmpty()) {
-            Webhook webhook = new Webhook(projectId, payloadUrl, secret, gitPushOnly);
+            Webhook webhook = new Webhook(projectId, payloadUrl, secret, gitPush, webhookType);
             webhook.save();
         }
         // TODO : Raise appropriate error when required field is empty
@@ -734,7 +735,7 @@ public class Webhook extends Model implements ResourceConvertible {
                 ", project=" + project +
                 ", payloadUrl='" + payloadUrl + '\'' +
                 ", secret='" + secret + '\'' +
-                ", gitPushOnly=" + gitPushOnly +
+                ", gitPush=" + gitPush +
                 ", webhookType=" + webhookType +
                 ", createdAt=" + createdAt +
                 '}';

--- a/app/models/Webhook.java
+++ b/app/models/Webhook.java
@@ -656,13 +656,27 @@ public class Webhook extends Model implements ResourceConvertible {
         }
     }
 
-    // Commit
+    // Commit (message)
     public void sendRequestToPayloadUrl(List<RevCommit> commits, List<String> refNames, User sender, String title) {
-        String requestBodyString = buildRequestBody(commits, refNames, sender, title);
+        String requestBodyString = "";
+        String requestMessage = buildRequestBody(commits, refNames, sender, title);
+        requestBodyString = buildTextPropertyOnlyJSON(requestMessage);
         sendRequest(requestBodyString);
     }
 
     private String buildRequestBody(List<RevCommit> commits, List<String> refNames, User sender, String title) {
+        StringBuilder requestMessage = new StringBuilder();
+        requestMessage.append(Messages.get(Lang.defaultLang(), "notification.pushed.commits.to", project.name, commits.size(), refNames.get(0)));
+        return requestMessage.toString();
+    }
+
+    // Commit (json)
+    public void sendRequestToPayloadUrl(List<RevCommit> commits, List<String> refNames, User sender) {
+        String requestBodyString = buildRequestBody(commits, refNames, sender);
+        sendRequest(requestBodyString);
+    }
+
+    private String buildRequestBody(List<RevCommit> commits, List<String> refNames, User sender) {
         ObjectNode requestBody = Json.newObject();
         ObjectMapper mapper = new ObjectMapper();
         ArrayNode refNamesNodes = mapper.createArrayNode();

--- a/app/models/enumeration/WebhookType.java
+++ b/app/models/enumeration/WebhookType.java
@@ -7,7 +7,7 @@
 package models.enumeration;
 
 public enum WebhookType {
-    SIMPLE(0), DETAIL_SLACK(1), DETAIL_HANGOUT_CHAT(2);
+    SIMPLE(0), DETAIL_SLACK(1), DETAIL_HANGOUT_CHAT(2), JSON(3);
 
     private int type;
 

--- a/app/views/project/partial_webhooks_list.scala.html
+++ b/app/views/project/partial_webhooks_list.scala.html
@@ -40,7 +40,7 @@
       <strong>Type of message</strong>
     </div>
     <div class="span2 secret text-center">
-      <strong>Just the push event</strong>
+      <strong>Include git push events</strong>
     </div>
     <div class="span1 secret text-center"></div>
 
@@ -68,8 +68,7 @@
         </h6>
       </div>
       <div class="span2 text-center">
-          <input type="checkbox" @if(webhook.gitPushOnly){checked} onclick="return false;" />
-
+          <input type="checkbox" @if(webhook.gitPush){checked} onclick="return false;" />
       </div>
       <div class="span1 text-center">
         <button type="button" class="ybtn ybtn-danger ybtn-small" data-request-method="delete" data-request-uri="@routes.ProjectApp.deleteWebhook(project.owner, project.name, webhook.id)">

--- a/app/views/project/webhooks.scala.html
+++ b/app/views/project/webhooks.scala.html
@@ -18,26 +18,36 @@
       @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.WEBHOOK)) {
       <form id="formNewWebhook" action="@routes.ProjectApp.newWebhook(project.owner, project.name)" method="post" class="new-webhook-wrap">
         <strong class="form-legend">@Messages("project.webhook.new")</strong>
-        <div class="form-wrap">
+        <div class="form-wrap form-actions">
           <div>
             <input type="text" name="payloadUrl" class="input-webhook-payload" maxlength="2000" autocomplete="off" placeholder="@Messages("project.webhook.payloadUrl")">
             <input type="text" name="secret" class="input-webhook-secret" maxlength="250" autocomplete="off" placeholder="@Messages("project.webhook.secret")">
-            <select class="form-control" title="add details or not" name="webhookType">
-              <option value="SIMPLE">SIMPLE Version (no details)</option>
-              <option value="DETAIL_SLACK">DETAIL Version (for slack) </option>
-              <option value="DETAIL_HANGOUT_CHAT">DETAIL Version (for Hangout Chat) </option>
-            </select>
-            <label for="gitPushOnly">@Messages("project.webhook.gitPushOnly")</label>
-            <input type="checkbox" id="gitPushOnly" name="gitPushOnly" class="form-check-input">
+            <button type="submit" class="ybtn ybtn-primary btn-submit">@Messages("project.webhook.add")</button>
+          </div>
+          <div>
+            <label class="radio inline">
+              <input type="radio" name="webhookType" value="SIMPLE" checked> Messenger (Only text)
+            </label>
+            <label class="radio inline">
+              <input type="radio" name="webhookType" value="DETAIL_SLACK"> Slack (Meta)
+            </label>
+            <label class="radio inline">
+              <input type="radio" name="webhookType" value="DETAIL_HANGOUT_CHAT"> Google Chat (Thread)
+            </label>
+            <label class="radio inline">
+              <input type="radio" name="webhookType" value="JSON"> Continuous Integration tool (Only push event)
+            </label>
+            <label class="radio inline"> | </label><label class="radio inline"></label>
+            <label class="checkbox inline" for="gitPush">
+              <input type="checkbox" id="gitPush" name="gitPush" class="form-check-input"> @Messages("project.webhook.includeGitPush")
+            </label>
           </div>
         </div>
-        <button type="submit" class="ybtn ybtn-primary btn-submit">@Messages("project.webhook.add")</button>
         <div>
-        @Html(Messages("project.webhook.help"))
+          @Html(Messages("project.webhook.help"))
         </div>
       </form>
       }
-
       <div id="webhooksList" class="webhook-list-wrap">
         @partial_webhooks_list(project, webhooks)
       </div>
@@ -50,6 +60,16 @@
         "form": "#formNewWebhook",
         "list": "#webhooksList"
       });
+      $('input[type=radio][name=webhookType]').change(function() {
+        if (this.value == 'JSON') {
+          $("input:checkbox[name=gitPush]").attr('checked', true);
+          $("input:checkbox[name=gitPush]").attr('onclick', 'return false;');
+        } else {
+          $("input:checkbox[name=gitPush]").attr('onclick', '');
+          $("input:checkbox[name=gitPush]").attr('checked', false);
+        }
+      });
     });
   </script>
 }
+

--- a/conf/evolutions/default/28.sql
+++ b/conf/evolutions/default/28.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+UPDATE webhook SET webhook_type = 3 WHERE git_push_only = 1;
+ALTER TABLE webhook CHANGE git_push_only git_push tinyint(1);
+
+# --- !Downs
+ALTER TABLE webhook CHANGE git_push git_push_only tinyint(1);
+UPDATE webhook SET git_push_only = 1 WHERE webhook_type = 3;
+UPDATE webhook SET webhook_type = 0 WHERE webhook_type = 3;
+

--- a/conf/messages
+++ b/conf/messages
@@ -727,6 +727,7 @@ project.webhook.payloadUrl.tooLong = The given payload URL is too long. (Maximum
 project.webhook.secret = Authorization Token
 project.webhook.secret.tooLong = The given secret token is too long. (Maximum 250 Characters)
 project.webhook.gitPushOnly = Git push hook
+project.webhook.includeGitPush = Include git push events
 project.you.are.not.watching = You are not watching the {0} project.
 project.you.are.watching = You are watching the {0} project.
 project.you.may.want.to.be.a.member = You can send a sign-up request for the {0} project.

--- a/conf/messages.ko-KR
+++ b/conf/messages.ko-KR
@@ -726,6 +726,7 @@ project.webhook.payloadUrl = 전송할 주소
 project.webhook.payloadUrl.empty = Paylaod URL 은 필수 필드입니다.
 project.webhook.payloadUrl.tooLong = Payload URL 이 너무 깁니다 (최대 2000글자)웹후크 추가
 project.webhook.gitPushOnly = Git push 시에만 동작을 원하면 체크
+project.webhook.IncludeGitPush = Git Push event 를 포함하려면 체크
 project.webhook.secret = Authorization Token
 project.webhook.secret.tooLong = 보안 토큰이 너무 깁니다. (최대 250 글자)
 project.you.are.not.watching = {0} 프로젝트를 지켜보고 있지 않습니다.


### PR DESCRIPTION
git push 시 webhook 발생과 관련된 이슈와 함께 UI 에서 혼란이 오는 점을 개선하였습니다.

- 기존 git push only 옵션으로 구동되던 형식을 Continuous Integration tool (Only push event) 으로 새롭게 만들었습니다.
- 모든 타입에서 git push webhook 이 구동되게 하였으나 오히려 너무 많은 양의 webhook message 를 발생시킬 수 있어 이를 옵션으로 만들었습니다.

<img width="980" alt="Screen Shot 2020-06-08 at 4 15 43 PM" src="https://user-images.githubusercontent.com/6521335/84002437-68215600-a9a3-11ea-813b-83cdf03ba242.png">

